### PR TITLE
Fix unit file syntax (ExecPreStart->ExecStartPre)

### DIFF
--- a/gpio-trigger@.service
+++ b/gpio-trigger@.service
@@ -3,8 +3,8 @@ Description=WiringPi GPIO Trigger
 
 [Service]
 EnvironmentFile=/etc/systemd-gpio/%i
-ExecPreStart=/usr/bin/gpio -g mode $GPIO in
-ExecPreStart=/usr/bin/gpio -g mode $GPIO $MODE
+ExecStartPre=/usr/bin/gpio -g mode $GPIO in
+ExecStartPre=/usr/bin/gpio -g mode $GPIO $MODE
 ExecStart=/bin/sh -c "while gpio -g wfi $GPIO $DIR; do echo \"$MESSAGE\"; $COMMAND; sleep $DEBOUNCE; done"
 Restart=on-success
 


### PR DESCRIPTION
`ExecPreStart` is a typo: it should be `ExecStartPre`, as described in the systemd.service man page: https://www.freedesktop.org/software/systemd/man/systemd.service.html